### PR TITLE
Fix jobs to run with latest oooq

### DIFF
--- a/globals/macros.yaml
+++ b/globals/macros.yaml
@@ -28,6 +28,7 @@
           --tags all \
           --skip-tags overcloud-validate,teardown-provision \
           --requirements {requirements} \
+          --requirements quickstart-extras-requirements.txt \
           --config {config} \
           --release {release} \
           --playbook {playbook} {extras} \

--- a/globals/oooq.yaml
+++ b/globals/oooq.yaml
@@ -41,7 +41,6 @@
       - clone-oooq
       - clone-collect-logs
     builders:
-      - cleanup-environment
       - oooq-export-vars
       - shell: |
           socketdir=$(mktemp -d /tmp/sockXXXXXX)


### PR DESCRIPTION
Upstream oooq made a breaking change to our CI environment
so I've hardcoded the new 'quickstart-extra-requirements.txt'
file.

Additionally, the validate job was cleaning up the environment
which is unnecessary (and not desired) when doing a validation
chaining job.