### PR TITLE
Use 'ip route' to get primary ipv4 address

### DIFF
--- a/globals/macros.yaml
+++ b/globals/macros.yaml
@@ -21,7 +21,7 @@
       - shell: |
           sshvars=($SSH_CLIENT)
           JENKINS_MASTER_IP=${{sshvars[0]}}
-          JENKINS_SLAVE_IP=$(hostname --ip-address)
+          JENKINS_SLAVE_IP=$(ip route get 1 | awk '{ print $NF; exit }')
 
           pushd tripleo-quickstart
           bash ./quickstart.sh \
@@ -66,7 +66,7 @@
         - shell: |
             sshvars=($SSH_CLIENT)
             JENKINS_MASTER_IP=${{sshvars[0]}}
-            JENKINS_SLAVE_IP=$(hostname --ip-address)
+            JENKINS_SLAVE_IP=$(ip route get 1 | awk '{ print $NF; exit }')
 
             # install additional role due to a bug in naming
             ansible-galaxy install --role-file=${{WORKSPACE}}/tripleo-quickstart/ansible-role-requirements.yml --force -p /home/stack/quickstart/usr/local/share/tripleo-quickstart/roles


### PR DESCRIPTION
sometimes `hostname --ip-address` returns multiple
ipv4 & ipv6 addresses which in turn break the auto
deployment, for example:

JENKINS_SLAVE_IP="fe80::79d0:e5d7:2aa7:5760%enp4s0f0
                  10.112.213.211 192.168.122.1
                  192.168.23.1"

Signed-off-by: zshi <zshi@redhat.com>