### PR TITLE
Escape braces causing deployment failures

### DIFF
--- a/globals/macros.yaml
+++ b/globals/macros.yaml
@@ -21,8 +21,7 @@
       - shell: |
           sshvars=($SSH_CLIENT)
           JENKINS_MASTER_IP=${{sshvars[0]}}
-          JENKINS_SLAVE_IP=$(ip route get 1 | awk '{ print $NF; exit }')
-
+          JENKINS_SLAVE_IP=$(ip route get 1 | awk '{{ print $NF; exit }}')
           pushd tripleo-quickstart
           bash ./quickstart.sh \
           --working-dir {working-dir} \
@@ -66,7 +65,7 @@
         - shell: |
             sshvars=($SSH_CLIENT)
             JENKINS_MASTER_IP=${{sshvars[0]}}
-            JENKINS_SLAVE_IP=$(ip route get 1 | awk '{ print $NF; exit }')
+            JENKINS_SLAVE_IP=$(ip route get 1 | awk '{{ print $NF; exit }}')
 
             # install additional role due to a bug in naming
             ansible-galaxy install --role-file=${{WORKSPACE}}/tripleo-quickstart/ansible-role-requirements.yml --force -p /home/stack/quickstart/usr/local/share/tripleo-quickstart/roles


### PR DESCRIPTION
Unfortunately the change in 27305f47e46048c8da4ee3f59f42afc5c6846ed4 results
in unescaped braces. This change should resolve the breaking changes.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>